### PR TITLE
fix: Upgrade kosko-charts.

### DIFF
--- a/.k8s/__tests__/__snapshots__/dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-gjtkk:p-8j5hf
     git/branch: refs/heads/mybranch
@@ -18,6 +20,7 @@ metadata:
   labels:
     azure-pg-admin-user: fce
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -37,6 +40,7 @@ metadata:
   labels:
     app: client
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -60,6 +64,7 @@ spec:
       labels:
         app: client
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -119,6 +124,7 @@ metadata:
     app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -135,6 +141,7 @@ metadata:
   labels:
     app: client
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -157,7 +164,7 @@ spec:
     app: client
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -172,6 +179,7 @@ metadata:
   labels:
     app: client
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -183,9 +191,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: client
-              servicePort: 80
+              service:
+                name: client
+                port:
+                  name: http
             path: /
+            pathType: Prefix
           - path: /api
             pathType: Prefix
             backend:
@@ -210,6 +221,7 @@ metadata:
   labels:
     app: n8n
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -233,6 +245,7 @@ spec:
       labels:
         app: n8n
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -241,26 +254,19 @@ spec:
         - image: >-
             ghcr.io/socialgouv/fce/n8n:sha-0123456789abcdefghijklmnopqrstuvwxyz0123
           livenessProbe:
-            failureThreshold: 6
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 60
           name: n8n
           ports:
             - containerPort: 5678
               name: http
           readinessProbe:
-            failureThreshold: 15
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 1
+            initialDelaySeconds: 60
           resources:
             limits:
               cpu: 500m
@@ -269,11 +275,10 @@ spec:
               cpu: 50m
               memory: 128Mi
           startupProbe:
-            failureThreshold: 12
             httpGet:
               path: /healthz
               port: http
-            periodSeconds: 5
+            initialDelaySeconds: 60
           volumeMounts:
             - name: downloads
               mountPath: /tmp/download
@@ -306,6 +311,7 @@ metadata:
   namespace: fce-mybranch
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -323,6 +329,20 @@ spec:
       AgA5yfdvG0fGNmiFmzeFtRwLEJ8c2QPGT/04TWyNanjKOHedOk/yQpnJ/s3r14iYYzHTkeNtvjYaBsB8xwPIKX5bn+vHsM4i2poqnP2UrmIDspOdkbYnwpamkOZpD5f6Y8tCpJukym4F0D6XYmaimtbnUUepz9ipAgp/iPtBi2aU1bYL9zqW3fzkV51O0U11xbeiVaTD+ClClnt+Ehpwxu05454uIRuAkW3EqRi4DAH8CRWPAvAUHNUKYTYj4mhR+kiCwc4sR44jtCMTT2STlbu4bgW/Kj/aTrQYcL8AakVzWl/fyA+drrrGYdPTGnl1nNEPHmdG9neigN6Bkn500gA5tNA4clpKWiJoTWKv0YElsPwpDA5lsNGqP/bZtP71WngwyFwsQHrkbjNhPJ6bEeT+deSNCtKgA/Rtpxi6J8D7/uIpCCU/BhgMeBCg1NTfd2K9x5/zFU83MZ74+4E02WMFBHYGgBJO9tP7ex8qNWevpO9GXNyH09cpR9QWcpCfdRAZcgCcQmMkYcrWHzd6kVoEl1yr3Agh2RFDdSYcSz1XKUV8VJzhg/Vq28Jsx3Ci9jXExrQm5cDF4YmRu/Ox+E+5DFcCHLIjqLteZqWLx9x2TMkgK32o/q2WnU6T5Bi5Si0lGb/zLn7/Gf4QrW477ePDrkRyOCH4Rxxw+y8M3A19/vfkEj3E/w7v8bJefLTxobpKQAE=
     N8N_BASIC_AUTH_PASSWORD: >-
       AgBeEMikMnCob0Kq4cLsnZcrbVgO5P5nB2eW2LGsDEcffna94VEKvpo1Q9J/peixlpeSI6r647HfVKqC+Po0FzGCy5un1sQ7pEX7NfYAk/+zLRo+cuaf6sY6nKdcYC9Jp2CTf6YZlBR5RLY8uEJ4tuYuXuBbabNh1HEZPvPMzvTg371JRVUgBvF8ZUedDAxl1LF3Iqf5YLgvlIi1IYtuajg8YArZNkr57fuNr4OeaEWojE5MTQQJ1QI4CsECGN295PmjLHntW83u0bksJfejrP0CobxeLFXS5GjcRtd7UQGF+7oQYWNohLByS1TSkWCasb4OLl3fQMwwdfZKF/gfqT5jwQ1EVtgrmXXvOVIMuuTqx5qg85Cr4aeDYuEK4+THQaRpBlzMBBP3kSorb4+5bS7NadsiLULu+XtNkbt2ecKpwT9GTWxgZZXnB+C1SPy55IY1XXHLfXT0O/DZvF2CQrGv37fW9QDlkRpZAdRlphN+sCmSyu6H9Nqa5CN+U4yFc9cmrQQNpL5saDhK4kU0bmeIO3cxU490z+saWxlnhhlZU89qqgBm7X99togdAZRgMZt3YRn0ZViYwlAo7FSLVcytJbj7eSa1ifFAIuy2fYW52nmJPhsRQUfIqZ0pCrz/Ho4aMAP4/btRuR1XKhQMOtJVz+2VOPdRxIal3luBtQTFnjUjFECNVQgFcRYxJEOtWlFFLzgm0J1nSaEDA8f03A4CzR832Xm3QMO7gvOLpFPsPA==
+    PG_HOST: >-
+      AgAyNnKPmupks15ubh8d3T3vD/fy6v91CbDVpocmYls+ddoMZH81Nn/y7AN06R693yn/0gz3JfdbIfoDasVnd5L34G8chN8wqMTWL1aKluHtF5YCpGZNSCX+xM1vbwBwuOJ4rXqUgISHTv/A6COGNcWYWgrUSDw+uFx/NW30yS7dsJRFdwE8OuE9cBq0B1zLaBfhJYK/cPUXUoM1vny+DAknTXJ8PQrLPhIHrJUkPpBoLp+NbaKAwHaEYTLVGlT5oD5wIoscWmTId4dcuwTPZSMkNOHVZ9S00HEcQzEyCABPxlwhFg9lnVOXCu6KhF19U1pd4frHgKBFM9SVyWIf99rXMF8K96k2iEZZxP5i4ppMbABMzAgZkpTj+DoGq02lcNozzzHmuLj7iub6d4GvxVQngAMrMI5eXw1vl0us0uDX17a7Ai7wZfrtD2+Vj3fs3Dpl0tB0iNvDy9k6PgLxIT3F6VidFLra1L/VrQa6FxqiPWunoHGbAJMNYVP0FmOMEccjMriuE5vb6M0ItwKOuQPv8wgp6pvrHVZ4fMnEdaqi6mDvkFhBTFF4aWQZ4xy33DLjveiTj1wpm5qo2i7J55RLXjvMSuygdAN3KsI3j73ds0PSysW/smZSojEFN8xTS/erwNwOrT6Z2Vx4hp2JgfMG6kJbiFtzW3Irekihy7llEDHRfUzr5DB/WLKKH6qzSiNro6egb1oljIczpG6ohnVSn+TJw77PHKS+6R3//zstPw7WAg==
+    PG_DATABASE: >-
+      AgAIj//mZ0CF9f95lIlaNN5/ldcy8xJr+zwX4P3hpRXyjE0ib1d/jKkXZ2ILQT6MVgv1mEzdxndk73iPC1M+TA2nmAbRFRCoYZOi+l2AQItv9jJmxpFi6HAge3+s6PGiWrcVF5d1PTShUry6MADCyTng3XfdAVUpCcAurgeSu2ryoRw5al0WUGfXBjY4oW5xMVYydxPSXE2N8Ws/xpjWRLHSgLPFtp59zf1Kj/SMTvP/bD8YJ/RFFq6hdmkrt4n+wHo9DpLoQCPf9H2MW1O8o4lEtSSEyTELS9S+tU9/iEpaSGNN5w/fNz7jIKbtNAgkZz+Gq7xBiw+y2lvW7hf5xIUJ8bNhGExVfC1indFUoA/duOvrXiXaw7RVN6A2EMf1NyXpwoM0s96K9rj2rClwlEzC+WzI4he3/H8n7YY7Wzr6JBRTZ6GK2em0X6qEDKCReDRmET2YVIQf48OV2M2aHWo3/4/OzhQ6/NkPR6fw+09h6aD8gVlkCPa2K9jReNHzj89SipSRRFo1OV5QZ+iRAoEbp3kPy4DFGoJbQpMxqhFmgGUvk+rRCL/bz/bFvXwfePAG460RQp+aNLuAeQfapUPD5vVsNC4MIoTWSei4ECZdl5PTl2/1eink76SDiCJ8fEam1RXoCG7JIfeisN0599+4tr0eRCj8L19dNIrrhE6TMW5lTa/TjFc+kzW39QdtqFp58OM5IQ==
+    PG_USERNAME: >-
+      AgB1yptJOgdyXN12ZORybPqPIoe1yY9rAA5XARtjAK4Jq+hq8Le3H7ltZfB6NdU/jzU1aJjRlfFkW6aUg9f5XCGoQHo3E9xmS3U+KKvPRTVwNB3UMgWHGvIwf4Y7DhA8ekTPSz5Vp2aMdO0mbPbXJBhcTVtQu5SGWUhLnItteKmI+05XoEZBnkO7F3eYTUh3H04OT/e5iV5xPLrbR4+FU5rTyFYG5p8RZq54bb51YD3I7RFPlo9+XbJtr0It7zpoVIunswJ7Se3CMDWJHs7RuNokuCkKa22zkTQuputoEefy0OIjzA1IJJz2LOIahKD0Z6dqzLKMLBf6twA/D9leWloUtgyd0MHqKtRtrgWeD2cRA6wp9+wydvrLvNXUKkrjFD/A+t1iO3A+JR0lXzpnodryl/CcRD9SUGfkQ3nSZWLQOQOYr6NMmD4hil3oqW2JWVrtZHuUtuIbvIWzAjVVmpkw0lwQoTHaQTsOU5eKZ3cHuLJaP90J1U1V4S+3Wiva0255imklNHKJjx9QFawBf6vNKWNaQk6f5WM6tZP0v2o3ktsjzXfIXxVr8j67L7aV8EZhtyaommK2NRYjoLuijASd5yyGGkaFIWMhWuMtY9RtnbgBFiAlt/yZpYSSRBPXAdh0X2nHH5xt7Gn1Ewqarhoe84pp3jWnhv5ZeZXceXr8vraNmYpHP4PvGi4uqswsWr2czH01oPxDa/spv3s=
+    PG_PASSWORD: >-
+      AgC6Z6p766k+k2Xx4DBUj9f6LaZAJIRczgegm9PWfbssif6jlWKU3tg+24Q0zPav1A+T9eU+CUPDNgzmv+mRSvLME+MKnnn6xMvlqvl3g4+/lxMc7Y8DpiiAv/TYrxcDCnA8UEoNpNeXrbtEZvXdUnCJKgrl9/qefJ7dORBsS8Vl9S/4mzAA8j8yF0qAPBvfy+oGOlSvMiRkRF94rUMGw1wZJfL/F4VEZorPq2L5qBSlEqznJW75XrkE7q8sa6NuzZqaEgNICNvL4RdGSHSZfLt8BF3qnw3rCwCtOMBgV8dCF2GzcCCIsACnVQA1APcGDswba6hGGGo0gSCG6OvD7bMlkuUwdQZXreW7BPT3Ax5GUtw0u3lxLB7y50RwBNU94UZ27/5I+Umcsj+rJiuVZ0NTMb0E0snHK9vNr8E89442dy9NGNgS8UlNlb0Gf+NY1/d/Iah+24qemoBuwpbHewh2BO5tp9sUURx2fRKEyivUdhu3wySjiOjAMiYcNfEW6hkXFZz1yZ6/0sEdMHAd3Fdur7fujgSpVBSDkl+QzGc0gvIHrhvcPanLNY47FDT016uq/936PvPcFaY7nqpI6S5I9NbOdfEPVfuSGhduKqxqmjzU8NANeQ1NAc1d4yDaSgA6yeoHYcAC7iREHxP22Wjz7BSNlpwoNrF1nQw1SfvoSj9umYtunIClqqWABDupo0+FWsmEaRRQ7QzI9CPxwTg=
+    MINIO_ENDPOINT: >-
+      AgAfnRLD67EDf9uet3ft92x7fZacT5i1xLTfYTdoM+GGAv+yPnZnYErOgjDWUQqs83ZFs8PvSYKP7yCPNZbNrk97j98rZ5+PjH6SJLhpNp1cWFbahiW7u2ZsRQ/jDpqC6h1NFh4StEVmeGrWaOFgptYnLmrLgA0+KZO96UEAxB9+VBExOV9EQRZPNhLE5msEQvNUybzU2kfOJAdTv7tsZ4yqS4RrkpORSmQFWebx1kYeFj+W6yaGz3hgRqKiKWmpMhr/rQRzQCjHnOmQ7gRblJrbkgdOhgNZQd5PkaKJtKKc2p4hVsqFhBaXD3C0WwxXu7AzRBqyirKKTMslV6I6vW3pJ9APSpaBSWbCRrLzaOF5PZXdC8t40oLuGSQ3IMx2wO7jwVwnO1vhVyF1Xi+khrQMQCJojU3YoQYgVlpDjIkYy9Su9uikEKJjfHzZlnM6WIOoQJvzycb999j6ab1d+pVmbbfFtZgqufCYJStRGyqIDBTIH9PqZBYylGi+JuAl0QvTQvI0tSlbf/Il0t8qLUOM7wBrq4JrkOzkOuWTSthJKjSqFqmgh1nwRBpY6tjO4wMoe/ROA6r7nuagfYDPgy8CEFaey4NZPr809Tz2fSc5wuIFR9lps7sS/I7q4qlRJZ91/GqG0/IRpNDvv4CtjTB3iv4V09+zBqBX8Q5h/mE33/1etY0bFuQ9gQ46QsOD6rlXyzsoL5Cf1R6SMhlo0e1k8JgH2zKAOuNYmUVF/rev5ig=
+    MINIO_USERNAME: >-
+      AgCZIyWmRdOh0PtkPtVE/eiw91+/Rgv4OfYmH7xBBiESCJBaPAHdmvMgNsjTEnhMrjzhAgUBD+ucyqMuZdOvzb0+ybFowPJ/ZG69LitYIiL99+B8xvgxZaoFCIc2we624WJSOYzzW5i9ITICNgvhrddX8J1sbvV8ZuMlgLaVBjdL0BUkR/zJhRhmKjC1zlh9Z/NinCTC/Afmkoc7CykMsstPwfKCjgjMlBnIZEel9fERcjzHPPxlzkQEsxm8ZCV+IbwK9D0AmYdrjQg082NMtIpTsDlcvd+7iJ8/sGmlK6TXDHVMKu+TmfPicXZoP2HC+LpNKjfn98/SnJGnpLZOcgxfMLXSznl6xvIA5UaCD7ZyBE0LoMOs98RhDkC8ioyTvGeV83jkKV7ZXOcwplpVOByrBDC6AiQgevWyGyBUVY0rl4ecAlKjXOVkgn+2zettMSilwTV3HIuI4Kj4h2fnaaZ/VvkNSHGA2ZhCPIDfZ1RoOUDIH5fNP0i5NPUmoOLstGfqlNBmlORvgtTxOQK3K8C3bHWUG4gnoSzpu0IYZnLxhFTmQJNw7r9ryjBNiyPRBfCwgUNRW37E3x+cTta66bXhlYlXlUXuohJ4N3PRRQFCiq7ZsnqEW9KSaQ/c/Sdgsl1x+hmLiP7ER4SxV0KfcN5y6TyyCDST/ZpDJ78LsH9wjrNMGbvKafoFa1zd2ElYnjFrkLxJPStlwA==
+    MINIO_PASSWORD: >-
+      AgAubcdluAX8mXcsd9SnLgs2aSe7021YXhUKnXyQruBN9OtK+We/ju8824XTwrvDDWNmpepiZGjJLr5UcdLu8xe2kj/YuSUhTr2HRdVXM55vfQyirIVwqq2t7jI/aIh0dn7geViKTjAZoEj4WgTzLowt9xu2eCYd2Lek1Vuu0xlUPoVoCQY72ZFmzRb5Nuhti8Hvvkixw4rOnfDIzMMc+DjVzS5XhtEFZBqoM6jHYxlSJjZ/Mco0bSVcmcz6nNU+YWBqc0AcQP2Q34rwI0ukkq4lTEnZXsJiyerodF9prj/oSvLeZxVkzMa1vApcTNV79GIaFjQcl9TACTg2HSVXqTec9hVGX8s5795oUsj3RtKNNS2JhBwv804BlJS3yMOkQS+hewrduRedtdDnYagNnFkkJTHJPODEctmU4B1Y/IYed9R4/ho+MIBdCh7LcNMcPs1TqMq2H2b0HsRoAEOz3B0npb1xKD8nB6KQexrfG9ZXYHpY5Rl6GZkrsKiMjgL+ySIymuq+xAQXTufDrYFFXlGCHGY4//Q3jlFk6cVJ4X4F4Mu8i5glnh1n0h65Fd1mFYCmAz34FPqXwmRm0GN/F7rdSr8vvOxygTqb6Ggxde7s4nVIEGyP0okTNCIOSmLIWJHyaijwdfmfUxrz6ZaaI91FMDK6TIUTyqyL79C0v6HYjC248jQPcN6iDVvLIzad16w6QnTyur5X7IntDoc3Y3ev5zeWLg==
   template:
     metadata:
       annotations:
@@ -337,6 +357,7 @@ spec:
       name: n8n-env
       labels:
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -356,6 +377,7 @@ metadata:
     app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -364,6 +386,10 @@ data:
   DB_TYPE: postgresdb
   N8N_PORT: '5678'
   N8N_BASIC_AUTH_ACTIVE: 'true'
+  PG_PORT: '5432'
+  PG_SSL: 'true'
+  MINIO_PORT: '443'
+  MINIO_SSL: 'true'
 ---
 apiVersion: v1
 kind: Service
@@ -371,6 +397,7 @@ metadata:
   labels:
     app: n8n
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -393,7 +420,7 @@ spec:
     app: n8n
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -408,6 +435,7 @@ metadata:
   labels:
     app: n8n
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -419,9 +447,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: n8n
-              servicePort: 80
+              service:
+                name: n8n
+                port:
+                  name: http
             path: /
+            pathType: Prefix
   tls:
     - hosts:
         - n8n-fce-mybranch.dev2.fabrique.social.gouv.fr
@@ -439,6 +470,7 @@ metadata:
     app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -460,6 +492,7 @@ metadata:
   labels:
     usage: fce-n8n-db
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -497,6 +530,7 @@ metadata:
   labels:
     app: server
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -520,6 +554,7 @@ spec:
       labels:
         app: server
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -583,6 +618,7 @@ metadata:
   namespace: fce-mybranch
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -638,6 +674,7 @@ spec:
       name: server-env
       labels:
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -657,6 +694,7 @@ metadata:
     app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -681,6 +719,7 @@ metadata:
   labels:
     app: server
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -716,6 +755,7 @@ metadata:
   name: azure-fce-volume
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -738,6 +778,7 @@ spec:
       name: azure-fce-volume
       labels:
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -757,6 +798,7 @@ metadata:
   labels:
     app: strapi
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -780,6 +822,7 @@ spec:
       labels:
         app: strapi
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -835,6 +878,7 @@ metadata:
   namespace: fce-mybranch
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -872,6 +916,7 @@ spec:
       name: strapi-env
       labels:
         application: fce
+        component: fce
         owner: fce
         team: fce
         cert: wildcard
@@ -891,6 +936,7 @@ metadata:
     app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -905,6 +951,7 @@ metadata:
   labels:
     app: strapi
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -927,7 +974,7 @@ spec:
     app: strapi
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -942,6 +989,7 @@ metadata:
   labels:
     app: strapi
     application: fce
+    component: fce
     owner: fce
     team: fce
     cert: wildcard
@@ -953,9 +1001,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: strapi
-              servicePort: 80
+              service:
+                name: strapi
+                port:
+                  name: http
             path: /
+            pathType: Prefix
   tls:
     - hosts:
         - strapi-fce-mybranch.dev2.fabrique.social.gouv.fr

--- a/.k8s/__tests__/__snapshots__/prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/prod.ts.snap
@@ -8,12 +8,15 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: client
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: client
@@ -28,12 +31,15 @@ spec:
       annotations:
         kapp.k14s.io/disable-default-ownership-label-rules: ''
         kapp.k14s.io/disable-default-label-scoping-rules: ''
-        app.gitlab.com/app: socialgouv-fce
-        app.gitlab.com/env: prod
-        app.gitlab.com/env.name: prod
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
       labels:
         app: client
         application: fce
+        component: fce
         owner: fce
         team: fce
     spec:
@@ -85,11 +91,14 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
   namespace: fce
@@ -105,15 +114,18 @@ metadata:
   labels:
     app: client
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: client
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   namespace: fce
 spec:
   ports:
@@ -124,21 +136,24 @@ spec:
     app: client
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/tls-acme: 'true'
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: client
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: client
@@ -149,9 +164,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: client
-              servicePort: 80
+              service:
+                name: client
+                port:
+                  name: http
             path: /
+            pathType: Prefix
           - path: /api
             pathType: Prefix
             backend:
@@ -168,12 +186,15 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: n8n
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: n8n
@@ -188,12 +209,15 @@ spec:
       annotations:
         kapp.k14s.io/disable-default-ownership-label-rules: ''
         kapp.k14s.io/disable-default-label-scoping-rules: ''
-        app.gitlab.com/app: socialgouv-fce
-        app.gitlab.com/env: prod
-        app.gitlab.com/env.name: prod
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
       labels:
         app: n8n
         application: fce
+        component: fce
         owner: fce
         team: fce
     spec:
@@ -201,26 +225,19 @@ spec:
         - image: >-
             ghcr.io/socialgouv/fce/n8n:sha-0123456789abcdefghijklmnopqrstuvwxyz0123
           livenessProbe:
-            failureThreshold: 6
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 60
           name: n8n
           ports:
             - containerPort: 5678
               name: http
           readinessProbe:
-            failureThreshold: 15
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 1
+            initialDelaySeconds: 60
           resources:
             limits:
               cpu: 500m
@@ -229,21 +246,116 @@ spec:
               cpu: 50m
               memory: 128Mi
           startupProbe:
-            failureThreshold: 12
             httpGet:
               path: /healthz
               port: http
-            periodSeconds: 5
+            initialDelaySeconds: 60
           volumeMounts:
             - name: downloads
               mountPath: /tmp/download
             - mountPath: /home/node/.n8n
               name: n8n-db
+          envFrom:
+            - secretRef:
+                name: n8n-env
+            - configMapRef:
+                name: n8n-env
       volumes:
         - name: downloads
         - name: n8n-db
           persistentVolumeClaim:
             claimName: n8n-db
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
+  name: n8n-env
+  namespace: fce
+  labels:
+    application: fce
+    component: fce
+    owner: fce
+    team: fce
+spec:
+  encryptedData:
+    DB_POSTGRESDB_HOST: >-
+      AgCq/maQiBymXkfrYlFh7GKYvR1z46RIfAHVooUtihxhmxpDjajmIOVH4JnKZ4wf//uJ0n5QoRdVCQl4N62qOCnJjZIK1l/GaROxmNLR96OzUInWKAyaXaUqoxvMK/Oi5ekMsPqi3yjm3CyWwAU3kxvCXr3hnQq4S4bfZuqtH+0yOolhnRqjsKLVsmM8bqxxv/iRz+KFeScQw59FqkaGhli8Zx675Vjj/o5a85gXay4U52bfBBmJW4TxKhqJf05CP4nkrlOsLqPrz0JgyyqVjHHpOQCJ5yInEhjNqNFam60GcilMrUuudOrYKI0gdlfygS9XR+3ODSUHAmbRnh/u3r2tI4lnMPYbzu/uudruwyXgqRGUxeWUSueVkJbjP79SOqg/bZlfYt1acJx0kUM/XMjsXLJ8s/yQ9Sukahrx7Ln+NKUiwvJI0/+XS3qmicaqfne2vA+F3WkR8dqpyT19UtzpkkG+WxHmViMWeLVoOjmHPVs90HPJYdjqOacBc/yDy1Hn8JBPuWUQVic925Rd88iN+y2212rgV9mvvxGHWuy0oWjm9xeLKugWeCLHDFvXvsLwAVUrOu+W6uyQatl5W6lBTjTYP+gffAnOp0Q1EOrSS8I6YrZIJYytCV76tv5+vWWonfgQtqPG6gLsoKtgO7ibLaCPqS++YzDla2aW6k/kSo1FxlERXmNn8CMGKODfIcg9W+mvmLFZUj5cBH7ilA7zW/Wqoo0p9pqARgqSer7kWzi/VmqgAw==
+    DB_POSTGRESDB_USER: >-
+      AgBz7LGvYtpM6MrxiGGJlKDsF2zcA9W85VD7piY2Xs96Qd55zrf5MVlJNno5lWspAUhbNPzvjeiNinkkdDS0APiUjcj9u9o1aCCwIxAUwvMlVatwck/ZfUxkooAhtD4TPfYHm8gUM/KFsqMkNzoVmaIbvaAOMDBEQBj0uswYI66rN4Uu3aWbXe3Jb+42uvM1MMyXjLemZGrlxcij9taoLaH8/0opHSwcvsSsxFWWF1hWnvHFasL8mPeCL34PXLIQpHjyEkyiJyTQ3MPjguBSMv34/JyKM1BElNAoJUhZ/zfeFGsr5bIqEWhhB/KUBL/0vMX4Nso5x1dyaMLoX9DKo41WH/xZ0UMk4iNHf9RCQvTP9t2kBxDClCOOcZ+x6CKpfxeEs6fl0qZU+YXekHipppohZXDYHrRVuyBI6Bgvi8dcqM6r1zi7Obtm8pp5NdknsTB9OCdY5i7xlQFQ1udavE0GlGP8MQqBH/w+5eCnU9Pvswoi0JYl2+E5caXdkyZElT8ePH8SzIbiXK9F+KUek2R29mzSZ7PQzsxu6lQYOAf+BoEIT+BHimQiuW3wAXYZgNrir2I8L5l2MwqUSgYOdKV/kczpWaJ7mHU7RfwuMjlow+qoKwHmjeIBP3VZX3rf6MD34Avm2oDZfVtAqiyBstT0ROFnFz+FI/KLWSnSxSu4oOKy+bNdBvHLgbn0BT4QsFqDjWt+/qFaknd+95zm3EqbldvQDXfj
+    DB_POSTGRESDB_PASSWORD: >-
+      AgBPBXDdabw66lRZ26bWdFl6Gz5Rog4tYjE2/mIhdTsZjJQa9TB8yRc+ovrQb3EJ7zGuZn8eo5zeymrIfSbGiCaWpjYxti9dAheE7VTKbGgyLUosT4tPhO6FP8girHZTtZqTK4z19nBEhQZ5TIRMGZhls7pGko+zrPNbvrpEegCLW9KsYVwFTdpSoCv+1sCvuh+V0m/qpBETuJEx1wXfVzgrOeAQ6XJEDlY5spiYCB0QAmKxPy/mVe6aG7wwSpw4dAQ828Dz2/YyA422w6N8RFoRC7SPoVGWtzH7Gy1D61WzxTf4LWg3++n9yQLSbtBs66+Y7YR1lEP2AcpcFguQ1A48cn3Cxmn7pEmI9Il1QurIUShwvzzkErlvIcKLERtWlgURqQBYQZQlbSpb0iWzSOYZEEsEjqta8RH8ppOgtDiq7Jz/QSNH3lx0T/4ulrcm8CJE14+eHDq8Lq5B4nvqGPf7LrmzBnvzb+BXZnNRWngxy48aN2wMjLna0ctHMApaJL/0ubeIJyL/2Kl0dXsIwKiHXIJGOB4HTaoNhxgA2YW8LcU380ARtJvAxR1USVeGeCCZAmfXkdfSYcgYOwbGP6XVG1d5TGY8lbAzAW1zP888LEOdaVX82OmKdIRv+cPtvZEd7D4B4nk7SwYHUxAKwjhMWakXEE/VXz/53BjWXxArjCXJzuQZcYk7J+33UXRgNsHuZyCWhkf9j3hHWUhew8c=
+    DB_POSTGRESDB_DATABASE: >-
+      AgCElLI9r2MEgMjda75Z7Xsqc8cBulyBi6nTlBwoeVwYu9asOBSCisKEr9ELMwYv0kqg+eahBzYks7fQFIfpboh4X5EUmd5RrIsRyVkUJxqZX+wsDtVY/RP2DDBEE7NiL4upMl9NarmtTFG7689XpdQdSw00TU8P2A0/nxXr0IyqM5aneKtOWMv0qQbhVxCMfLLabEaCjABQzNDkqagpoGNpFH5moQ+ESXPadCoWub+3ilTRyQMqRmMcjKA4TjhvmpHY1Yagh7ufC7dSXFk2LCLexonbKZ7bztbEvj/qYVmzeaPPH5mIQ83tuOb819SeTm4vL3oHGhdws4FeOaEejNKAb/029F8QBUqWfNMIEw1GG6IEt/HqUgjxDpczhBAF6p4YtCQwnTpM5XjXcdTinaSMi78YlTqwIFzK9mpd4GcisVsiXBZCoFzPWO0hNfJ/gKQss3Kl5HZzyR03inaIgAg/RSeSLo44Bbhk82Ms4vGqbWlmxENuVZ21f0kLXPZLktv7cQo0MMyjO7vkC0pcxVji47I8KH9anDGerdMJXqhMq4bB6wC4uKiyM3//l9IqNhZJCiF1fXqrKxmMnXj+hBkOr0CKHvfbT0DcgPJ06tVExa7nQ7e2e6LnvzQCCIxNHb096XNHQOK/zenukGO4swZpbPlDf2NKfdvGZa+NQuIeAcPvKw4q1na30jJqmWxpWrLIQMM=
+    N8N_BASIC_AUTH_USER: >-
+      AgApHN965oBlfs9q45MKCllGjabtMcdrHf1W8BgH77GLW6m8Y1FluyCOB0ZwnZNn8GgKZJjRfLGAr3C49vUCORBy2AURmhky1NGOaTR8AQosr8tY7G9JAOSqG9SR81u+Mmc+jADka7BZ14Z6TD/BKmsPnTw8r/lW5dCvRnvk6OtsaoNRKbI8qg3P8IvpFKw9MPJptD/JFQYFbFJQpNhqbBY88c3ncYHwu3qqGsP8G0/Oz4rTUSKPVjXxYMwQfhqKzpEgGSsvW5gJVHjvKr7NZgVLAMMRSt074oTwAE/oxV9v7O/WDTcPgsp0I7ylX0rDl1Y+FjU+XMcy9tEZdaUGgTX8a3qTks609eKdPjJwniZDrksynEOUGy4TW5tNFt5J7FCpuYYF9H0YKMRMFNIqjqpM6SbxwZrENpXd6pXsu5TyNIbL/v3PFv+/LCjMIcnHs30vZ35nO2JWIpFQStwiyvPw0eksx7WtdrnkLn58oUnUI6fmYizwELFCLilOjE4lxXW8nYVlTcWFhOoj/QYpySBDOBXRP2nIuG6508jVcZb5LWfdQlENYi1b1JAjHeQdv0usy5q9lTFp9q0bPU9x3q4UsbQlWNKMxHDpRU4IxPVbw8bCGARWeMjZZh9XhhBLimCkEuiJclTE0II/7OBUi++iRSwfZXNHoCPjMlv40eQ8dKy6oI0k6V65sQnZ20VEPgEmvCQ=
+    N8N_BASIC_AUTH_PASSWORD: >-
+      AgAsWISWcmZ3e+BbRMuDuLhtcHG86W8c1p82nDMLXcZZbrQpCvbBtprqzbK+JU9ftHPBpPMeBPfQxbX7UvYHvecljvLrsMGFdQYCG2yFV/Hi/y5bAjtJfpyW8kfIM7Qq7btcSX5ZuD52IKCB8C6KJovDx0OpyRQL9m8+fC/1NvecT95bfvV5WnNPrn/saKeuINRIG4P7JH5ztI7E22NP/fFv4btSoRVWo7OdpwaH+/mU+/yQO9sg5RfbLSoFvwTY5OtSJnmP5Y2F/7iPWRqmsAeUh1uwQKrmC8jOqDlQhcIRC3dbVYYWfxvJuwu+47qpDPQHT5pL2pT+TCdNJDMGN+wTLYc2FrD6NJBn3BMM293wVxG/2UuC+yQkde5B834HKa1t+ofuZRyb2gF5rVzbaBb8R4rULFPcwjf4va2kctAVkxUD8iFIXKs1NWbeCXfMSkRx/YogjXthesOrAH5iZHs/U2DsacKDsPGU5IGINjXHaOwlK+j1v6U31LpFjCHfVHRM8qqMZvzbIOqzpI3ANsOzl2fwaT9CcBO6hj5ScbnmbgHvhCNemLVT67zsa1RNRervyLC2oEMpNeRH/Ou1w8dH6H6OmVg7J9ig+C547chVptuPbvc8zKo4IdPvGPwlQozzrls+MiBHt7+wXsHY1rbb4AuX3EnCwoSqB9UCHfNp/E5ujiEawZkuAkVVBJqLAdlvqHXq8dDThmIJkkvBsUpEKgd2ifJyXVid7efETmC2CA==
+    PG_HOST: >-
+      AgB/kRibDKhYUdHIbFW8N1nE3pQOvdbZfnix4FEfR0CkPqp0DkLtjWAhVUg+sZzckKjN88VcNX4Kc9YZEe2E0aiw80x9eaBgnaVgOceIDjGw6Hm8mifCRET9AdzvavbdBb6uRF/bWv1W5oGJB5tGe5WG5mRSh7Hx/TjpxrVMMB2O6GTjaPVzB0tM+aNfAv4+zuwbedQ5yw9I5J83g0XJxG4QyHDrgG3QvY6zUZJwx3VSJOAqF/nBSFqccvlavjLGvnMCRCjxJK69vPDNVznu6ILQLJrYlJzWD7Qf8HcRxu4Tb/ea+oiSOq9ayLumfdz0pJu8is7Z6t/CfTb3kD3mN09m4tgtbUISpPI8p96ufPweLnBBwC4UqKP0k6xh6T94ykqmJDIZBf0E3oW1XZD+el+Ametzz9HuTtz4mlq9MP9ebDZ0bgtrhHZbxSD1RYpw+TPk24Sa11zZjo6WD0HiRIz/bzlKxg04ebkV7XFca0AzhfyAlHtjLGQRfW9CvP2SAGfMSgHIZGXDlHzTeaB1ZVFi213ISgKW/ShgfXQR7EDAhgddVEVU2NPu5iFlOFxoAesl+u7sadckEQQ9z4w6C4efsY+sI2+EvA7svVToAmOB1BKMIF92iwjLO3Pu3IO4EATd6MvR2u81QxUt8/OE5fTKNdmHv7x33dEGnuRMaF+J4ktli7w8EljBcPh7vyxYqiMN85hRfFyW31eQD7K6xgdP2uc5Wx1WfaqJIaHtXoXzeI1wop3hhw==
+    PG_DATABASE: >-
+      AgBOye9gL8gDApw7wVOjAQgraz6wUFXXrejLpJyQGNP5PIW39AKt0roIjh0jrGakNGLtKDY82LIEFAkztpNNE8z7SZoDqH4OdpEjk8budy/veTF7EwhtiFbmU6U05A3zsqm5tDIRWBQ+4UQWCLRul+C0Hz4pdsVByW2D/C2EpncRxdcc/QvAUxgGOFv/JXmKqbsfIRK+0SyuCZQMs5z1J3lKpBn2ei2fcY565KnHfjbTVUkeI9eO9mCZalNQp3leWBB7p71m97m4BG4G1IHAUTfHOg1Pktwq26Fp1UzIEv1NkRlyyXAcAHNMsHhDiKQSDofvgqDZbyM5rPEfNDxhEKlLM1DEEVfl/fzNmQ9nsSSm2rLnJoETL4tyhXSLKw+7q7JI9TlWephpE4lH6KJR46T0U6yqiwzW0MPOSPW8BsQlJrueJfG8mKMS4Nfk9u8rEleQH+p5pAnNaGqTffR4lYgabdcJdHEcLzErwYeft5SlfU8puhsPWEf64OxXnDkx31neCzKLmyf/89f/nJyE0aYe91L/QaFXE7RNdzus0mj/YAd2JGFz/9kuB76gU3D3gKbh1+ec3BLPyzJEqmtoiYAS9p4BxF6c7S7o9tv+vD5o8hs6I8w4peHjJjaOJbS2qbVoYtmmtthIXBPr87r/FKVSictXOlsYRCmXGK2sHQYF53nX7OS7sEUMSPcZE05xlZ3zB9w=
+    PG_USERNAME: >-
+      AgA8ye9k1SF5fhOCvvselUZcX4hKyzWNT72QBsRvDYNZxuBkH0R5xrIHcSKKo2Hh1T5ezusvLj9+FblE2LrlchOmRWEgE+EnKOEncJyqqs2r7ZNMgl2ETb4JGhN1XJqHrsBDJ6azVZmRKN/KSLNV0q4Z4kwP9vVNU4Zyr0uDPSrToMacGL6sbX+itrFp9H/S7QOjfH5jArXI207zNM8QjpDHvR1DRWdJm0LpUwz55fb0EAYbpGW4J4c5Kw3IKfAw+v6g24A5rnKwhD1gIGLa0nX85BAvCxJWS1T60hN09SiKDQgu1u498OZaG9aPpZwrwoGc5CsYPktloeTz+y3lDamoy8laf5b3pPQf0lw1t9Rnlx5rvXohkpoVWUZBOrt3rvd4DlcKlu+WfVKWACkJnAtKgcQeUko1gNBzlif/qQVgjMpB31+iTcooq+GxhdkuAUGtOIyUup2DINdK/7m+zZ4CIaEYCaw6tVNXqXeqfx8292uUq3TLXejBXKDSas2z5iMFoaGsS1x1xKAxB8QaQbzpMzU4CQ/n+zA7CtrW5qw3NkU7taQwnP9/MH3TnoLSS4+H4O3SotZ9iHewRep4PbXabHlAMKJWFPWBkqJB/dsu2EfxEhi9tF7dJHK8p2LNnT8OKXqnCa+knEq4+JR55/VE/uLIsjs1+/KGRNck4ZZZwtaTi0r2ZOwddLFfcU3e/ZV1Dkhtuyu8RkukxQJ33SWmqVEq6/wh
+    PG_PASSWORD: >-
+      AgAbiZuo+vpGNTGVc5/O19E0eXc5h8OY8rLl4ydUSAYaQ5c7cP8qhSu8kZQ5XhkKvmJj56igxNhGE6JrCS5uSUSJRcxT6WHH9cXSiw3Ood0vsSl2+Ik8T552nz4M2GR8dtiz4Ny/dt1TgNZtay1hPFHYAEdOR2ypaEKAXLtpEDhzwLtjOMIdiV9hgGC+kRYxSqpYtZbx0P/9WqkCEjX1b4XADzoBFhw5l/K7Mjscdu+8nK3g+KaC0Lf6ivY2nQsQ9eDX9FUrH8ca9Rv7D8V6pRbe0NZi459VDnCdBftM2Zob8SEQvjJ3WYoCu7guNWl81+JGjZADGva/HxzPiWO+yYiOjKT/GoyQ5DwxI2hR6bGbrYCofMx8RgPv2jQWw8LqMSXbytRxRYbInk+Q9viOs4A2DiA43wIV/S8/dSKierELKDQa4NWdqLK1HcnjzD2c2840it5g8FesQMkCLYVBXW1lhXkZG1ItFX1mB9wa+/CrdmGjdFEVJNRB4GJQUOGo4baobI4QB6MYzY2/CrC5Fc6oZzDJulK4UKoxddn0u6lSuIqcb7/CBxxMKs54OThWzLTZ66s17XcUSFZTJyX1Y0eyi1gt9LEMEdAtIRLozz6iDYk704zaH7Ge1lfMLAft4vtoLw4ha3WthCYMO+Yol2f1snmJ4t9EXvW7aTJYZz/W3qauzEK6bMnRx1i0d0+Me0c8lrUopQf8ZQmrMW1+J7E=
+    MINIO_ENDPOINT: >-
+      AgAygHinvR4IL/i0w2sIGZzDgo+Ho7MmoM6DUKW8wCKzx/5Tz/OrxlbqZ4q0JGx4bOr9icgTMkkcCV7wCaZbdAQQ9Awwz79mpEQem21U4uMv4cv9Zx8QbF4aM3+79hA1hzEtjt3auN+Va6TlQ0hSngAJz/91VoGZEu86W9G6UkFrMUhGFWqR9TtmIKJmVJ3+8f12yGXxtPp9QXyi2e8M4Mdo3WKaTOB/3aHQ0hjqyGbIV4zOcJ44YLfB4Z35uxlXa470DwKZm1T2JgSFpQ7ZbnT+2Snm19QGblWRYd4CfPI/bXSVBDSmGOOEsIqeQgNd7v3BbfCMKNcBzRJEoTRpc8/4tot0OG6PwtR4fTaYwXbcC0tbJ1fm9rzRPzFPW+7ldhUc5eyqVBZVyHiFJh7DbXu5MKymaUnz1IdXPEAuPYo40MDYA7WF5+r+7/bxyKFg12BVvZrTW57M3L5si61nFMau7ckxsLnQNDQLwoFPSAiKQuX4Rc9NnUG6zhqPKzxSDXPpPiyqQnj1xH5YNWccGr8tjv3ICcjSZK/XN/aWNiR+feflM8XmHcUMoI4IF1g0OXExgGDbK7+Tl0T3LgY5uw8URwYJYmXjY59yGBxrvg+hjgJ8N8UD5EeolxAkAUR+sYPHZX2vQI+Sbhkr8q/ahlPldI0TY7AZRWXHEy7qbEr34gaDCrKGLTH/gWaf+LTiatswPhnTpCaIWgOgcRoar9G3eSo47aropLmkKPWXPwxWgh4=
+    MINIO_USERNAME: >-
+      AgBqcAFkDStEl+/9lyjDaIba7dq0ANUa/4GvxHrbt9wHLgW+/XiqgUEP3WchhUN2KfhX+y4Mcr1eBApLwSQxXCD36yWE3MEsfwMzOONSsCgZYxM1KNIv4GhDzsW8cJcxlk3VBHrgOveZQdCNrlSxe3pbLBa6vFoglBzvCXkNDsTOI6n7PMPsW8Nakz7rdZ8frLnWc0c/IUw3fwBoSMnyIsbiZXOl/0tOeoao17ErtmY0TmQgEIpB8fOJacTnK6xNyYkTqHNLQ0PHE+b8Hwy/cY/MYdiuVlAvnWeIGzmMY0g0u+gkQjkCLOjUcl4pMVxIDl3uZCdGpMicVo/LyXtIcWOMUpfurfegatWIzIPAjDpnneaD+8meJijBMfxLHdX19w49Em+6IxCVYEJdR/fBww/iUlIVKfy9E63117hdowvwYIJfXauB5fLEI32KPymnCQPqcqI5Ba3ZHih7mCrBWR73vUa4OJSdiDCutKVExCo6SvqmZceHvtzW7NNNTGx+fXZTfPLs4I7LhrLLZDG1NQ8DgQi6kVft0uDFvmhQ/bmD8RMHo/o2b0Y9K/v38lIFZI3qyZJh0SrkTqaZZtqjGpI/IQ9Zi2nTSid/UXM+BY40Ip7H2QmWQwGZBtb3MymJ3VSmTgUyYKHV7zcCy10VPyZzoQPBYpddpkDwPLxPR2M/GPcSJE2uKsBjtDP54bCw46u/lNCHeiEQuQ==
+    MINIO_PASSWORD: >-
+      AgA1r94rKaO7Y7oaLNxXJ3G6bJnw8vQElGytgueZzUDiYE8kQFYi8aCky2FBDKyy3BNMgfpokIhIuegFcXEZVNP9zsabpVEA86fVWw3x5yaIWnvip3P6DUOe6+PJYL6Oos3Q0HW7Qse3gVX/zeo0Z4vBVztfQh7UTBWiD+aIWqe3gPwbXSsRCmM5kRBquJumUP1vAMXUohQKsQJdVEOfAaM5hMCBKCrN38R5WZghdstMZf6jTCLIReZv0KeS2+Z/7FCRk8UrSP20px95PjTpGdYeen8roHD9mw7X//H00WqPVTpg0t6RsTw4AOaueGFVDo/Wh0BeVse9aCcd4m+SWZPKkA5oeVRR6R72ns2H8LNPRwLwp7+v1QmCueG8aEFIOwUb+u1+UyVTK1woPl/dkbpevMKXpp0QeJcFBQdVrjgtIGxhp9rdFvKLYX5TfaeJbmSK4t3aW6BSeaTJXWloV+BRZO00In7YHLV6+tXHgCp4kBB/xRWpwXkLJfvifclieHeRh5KmuXgfkIixNzMSV5WrXwZVi4rHqVs/XcGxrqWsWzjxLl44pc+pLcfZj2MTFyovl5h6cTweILBatRskoPfXQQNHGKt8d2+xXOd8aFwAxpiBoM2m2UJsxOa2GtamtA3FnU51S/V2eB7EgBg1CKdGk+YD9WNPvSv7LD7LQBGX3PXZEnH8PB4AMi5/vj8JBpLk3QQ1QmALFCmUFjeqltYYOusORA==
+  template:
+    metadata:
+      annotations:
+        kapp.k14s.io/disable-default-ownership-label-rules: ''
+        kapp.k14s.io/disable-default-label-scoping-rules: ''
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
+      name: n8n-env
+      labels:
+        application: fce
+        component: fce
+        owner: fce
+        team: fce
+    type: Opaque
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: n8n-env
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
+  labels:
+    application: fce
+    component: fce
+    owner: fce
+    team: fce
+  namespace: fce
+data:
+  DB_TYPE: postgresdb
+  N8N_PORT: '5678'
+  N8N_BASIC_AUTH_ACTIVE: 'true'
+  PG_PORT: '5432'
+  PG_SSL: 'true'
+  MINIO_PORT: '443'
+  MINIO_SSL: 'true'
 ---
 apiVersion: v1
 kind: Service
@@ -251,15 +363,18 @@ metadata:
   labels:
     app: n8n
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: n8n
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   namespace: fce
 spec:
   ports:
@@ -270,21 +385,24 @@ spec:
     app: n8n
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/tls-acme: 'true'
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: n8n
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: n8n
@@ -295,9 +413,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: n8n
-              servicePort: 80
+              service:
+                name: n8n
+                port:
+                  name: http
             path: /
+            pathType: Prefix
   tls:
     - hosts:
         - n8n-fce.fabrique.social.gouv.fr
@@ -308,11 +429,14 @@ kind: PersistentVolumeClaim
 metadata:
   name: n8n-db
   annotations:
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
   namespace: fce
@@ -324,22 +448,25 @@ spec:
       storage: 1Gi
   selector:
     matchLabels:
-      usage: prod-n8n-db
+      usage: fce-n8n-db
   storageClassName: ''
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   labels:
-    usage: prod-n8n-db
+    usage: fce-n8n-db
     application: fce
+    component: fce
     owner: fce
     team: fce
-  name: prod-n8n-db
+  name: fce-n8n-db
   annotations:
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   namespace: fce
 spec:
   accessModes:
@@ -359,12 +486,15 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: server
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: server
@@ -379,12 +509,15 @@ spec:
       annotations:
         kapp.k14s.io/disable-default-ownership-label-rules: ''
         kapp.k14s.io/disable-default-label-scoping-rules: ''
-        app.gitlab.com/app: socialgouv-fce
-        app.gitlab.com/env: prod
-        app.gitlab.com/env.name: prod
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
       labels:
         app: server
         application: fce
+        component: fce
         owner: fce
         team: fce
     spec:
@@ -437,13 +570,16 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   name: server-env
   namespace: fce
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
 spec:
@@ -487,18 +623,21 @@ spec:
     EMAIL_SALT: >-
       AgAAPqlE+mQ4VCMXWJBmPt1iGCdbJFvOQYlearpaVprxTdUkFpe8aAixIg68+AZtvKGMhFGsyneYG2u6chm+cBaA5mLaYW3e+en5pEHPrtd69xlz0xJR2pDXqXtJbXPGyBnYlOXkVIKaZ+ayhlYzHAzXUWTtDyyOn2NYCK7WkI4Uzn24ej8+lGEcr1cLTYuZHmHh4QziL+hetjEvMHAjt/up142JY2O45IWLBlNaY6P2E4IGw4Qyf+Ybk8U/vD1J/6IRZkZI5TatPmin8peaoY8rI/zc+DjOTu3zeXqmCtTEuxwNUxMjiIB9QhXKOvaL+qkByJ4IfCBfBjjpsTt7v4O+IDvA4C79ksyOsewru+93uyfnH5BcSQ89VW+X8+51mqH5nw5C4CuipW/Ym+Bi2hETVSG8uU125FWn8N/JUlOE2+v3viDJhXKTm5ZDZY8NtmOKDEmFLjB5bceY4opkqerpEB6N3atZemr69wie1v5d2OZXt04CfrKtQGoUZYAVFK2H+t2lIn9tCfKj3VXqMY7Ilq0g1dBXrnHKDcQ8dlNIWuZ/AHzqGzJI+BaYLaLYHia438IAMKX+RgEFiqFrPrl3SOqrTuDAl9A3bHyK4We6zJH9uqSoAP0VrUYJkAvhHyoqlGAOicFfDy9PdZMILpbbTYcKRB2rdCR6sox8y1c32CTD5XOS1e/h9C2ldvP+V835nMD6sPoVdQDkqaeTc30SKEWe1wqwRpG2o4/6JGsLaEDJeEEdNyCDWSWlDinLBCPLPw==
     MATOMO_TOKEN_AUTH: >-
-      AgCYiKsTgPxdCT+cce4sOswL7dToePKHEOtSTDxYm4+NPXxzgRBsx1rqW2G+LLmlODHXmxtflF6fRJn+rR3lRVEMG9U14CFMZVVQ65tQN1kUZNzenDWYP9kEQxQdgQ3UpANE0iExVb/GDW+eEI4uRU8EIQ49a/QptEDFyg/DxUUyGL7+vzvY377u5J1uQdCjmyGStGfAD/RMZCaRBOCcXdAedlfPusumEYx8Jhfp4WIO4fbnRsfl6MynoQ8UC3BIL2hirDFOlINsyfF+MOadYLPdb2BwWKUKZjf9KdPJNSUu5NfWl+8Zg0UWxw/nuEV0fu+F3qUQAxSFFBT8nxr9RWSIXEiIqovYWy5Q0adrO1O6BFZUhG1Vcg2050xas38DVQLIpS2iyf5cBd5f+AR3FPZM7JnRR+PId9RP5YKLsIshTjtxfYJjDjjR6Q34JKOPJHkvZIFEkhcUqraKzOcxmuBxB/uQ/4sDYiO1x/J0JKi+PA3KWbBvjW2WrqETCyB2h4sQAsCJsXOHkLWc1zzwqa+faR3EqEM6C/R+4sVEvdlHrZOla4Yn67Qtu6P0tR01JPTAmdXA4rcDCz+IREiGSKv0MJcFXNMxrg41bqZtzMNkqx9Rfjwl7ssNxzbDwWgw9E0NzA3Ma7F+6ddm+XD9lTP47MneUV3LkDn8SabhzCXU0toHo13L93PUMIwqyKw4vK4JzrEojUVTuskoAxqYiNMeGuzzqSAstXc+H8fxX+Lu4Q==
+      AgCQIQBLQGJDWCz81PTbd9nAl/831TR4OdYFcqJtyfHM9DwEYARsl4zyeVjWrJMZNmdvkqA2D4IYI/t75CqOKo7iSMvLCWiT/AzX1tegLZ+7UNLwKJSGbvG6myAP6mixeFWgmVut/3C9MIqZByw0ErW4/538OpSVkBs9vm8UZ4sPI4iXO5t8E7xcHloVYwXqOlbJC1+LdzFCqXeM9Fv6Tq+86xSJAKmoDLWWHiP5cmN2V/wj/mjihnWavgfyegY1CRNjPygwwkXWd+uhPWWYdWEh5qAWn0fX4q6YNwyQuB1gogxhm/5OAqfVCfbW1WgjfBIw7Ldty7+pZZ1xHuMLUHQWe5EULTZmQv6I5ojIJayXIy/h0R5qN101h8uEuOy9J96oAiX6aZnQdTt/pPgIig2NuDi2UU+jNzsMmBXCV2j4I1+T7LT+7vmihzYUV6D2n1/ShgVHJcaIEq3aW0JkNjq0qeHlvTjNeCcOG2QfSSgfHbHHbxK+Vm6MT1cI0wICPXnn6InbtHseFkJ1uHjgCE4TliIaMP3Od1CijDqbXD9uBZCvYarN4wWj6otS67kXHs4COD1K4Hzuf4Xk/hJkPE1U1ZOZwdnS93+x+J2/4ts+TzBgexH0lh4RdXjTDRulWPb0tSJ0zE6gpWnZT3J7P22h75KrnzbI+CfSMZ5gz9AKvUjH9i7KYbVmXyyqoEAVocWN4mK/9RSqz07l2mkEeDJaqMV1cGC3cg+L4gvaZ8qUJA==
   template:
     metadata:
       annotations:
         kapp.k14s.io/disable-default-ownership-label-rules: ''
         kapp.k14s.io/disable-default-label-scoping-rules: ''
-        app.gitlab.com/app: socialgouv-fce
-        app.gitlab.com/env: prod
-        app.gitlab.com/env.name: prod
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
       name: server-env
       labels:
         application: fce
+        component: fce
         owner: fce
         team: fce
     type: Opaque
@@ -510,11 +649,14 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
   namespace: fce
@@ -538,15 +680,18 @@ metadata:
   labels:
     app: server
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: server
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   namespace: fce
 spec:
   ports:
@@ -557,18 +702,59 @@ spec:
     app: server
   type: ClusterIP
 ---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
+  name: azure-fce-volume
+  namespace: fce
+  labels:
+    application: fce
+    component: fce
+    owner: fce
+    team: fce
+spec:
+  encryptedData:
+    azurestorageaccountname: >-
+      AgCCbwpo4RYj+KYJfUArfcjxmVRuhUhciMTfXvpHs0ui37ivl1YDCmXmW3ylRqUx8qaw+DLL+PQPgyEzmdDVCNJ2hSky5x2yajfL0MmhHgkepoQSK1IELz3JHDKM+ShzSlRS0UiQnjDTysSf8xSFI/QUqcWQBOlJAEQCz8C1awiQz7aYdihL+bpyxH/uamgwRN3GWXMSMh05NjHo2zUZO6DfJ2qJYrzcy75s9+0wa8mwH6hA2kV89Aij9vrGm20DFj1iCe52FDUD6eqHcWe8vfz7vvWBPxC1lb6wp86jezxqdWWjieLn+imtVTTEhndInoyzzvWGtlU7ZIGcR7XqHhrwcxlkiT5LrG9RqGqyHIiJMGF9VpW3IlqdPJU1D/KFBDdOijB4U0aFsOBVaIxXFjtPhP8QO2huAtSgFcwNV1f1pRkhJzpMiY9mU257nDQyNRZInpGFAoV2FK4Nquuar8yGi3BsDk9LpqKejTNjYEHl/I1FitpwqIdttOYpx3JVKP29rZtjS9c9e5O2xgwDS3Q21GhOffKhHX+V+prDXA4I+BUpXkW+vNwB9NTt/WYyCG1hzDcPkHTuZyhNV0at7mfWec9zoZiUBw8m+Xrw64H88pIEJXM1E7BNoZfF/oqRdf46pAidcWMp2uPItVv6HEfa5JZGAL7Qtwm31vFZdGKdgWCF9PeMYIL5UdI2WAqsLj2np9eHXZPA
+    azurestorageaccountkey: >-
+      AgAlN7lsY17kIsFsYZ9CJ3wPb35eAM5s20oztZ+VTQNN3+ABCJT1PJozVZPo1btdElsGV3RAA6apU4A3L33fZZ6MTdhNY3cuTcHD9DZp7JjEWRtGRKImDb7HMDeoYSXfGjTSh6iThChDk9rvH+9M5SRZfGHIoVtKgr4d2FChOVylNmrwvX3hUBflhrvvKWHX+VIbvkRpr+1TeQtaPJn2JoaigDY9YzKviZ1nhER/oNqxRn3hpzAKFrwnLDKqzISwTfG8nTh6eUCfJgLxF6+4zVQtPBZCebWWPrxcqCar3zoLHvnZlkN3WkKk8BPeiAn/VX921fUdJdhecUIZCi6kTdv3vw8nLf5pMONpWvjsUYwqpr7spd/Pcua/vgAHUOw9V11pds837QPA5tcThfG5n4wiX/xeRw9N+jZqs3sFcuEqJQ0gqkmE1uisyMViOjn2z9UudtccAWL+Ll/KNbr8I6Fwy2SW0eUQh/aL0lafOyS/9fG6qAicg8nDI7C/bfKcS59y3S/p/kWFBz5GDCnjGJa8ezTkyUy8tIMe/gCs2RFvj6zaeOFTguFeRiSeFN9uOF9UooMcR+cPBSgtsAWGzmvZjYq0YYHTLacLTA1XqwOwVbDV4IgXAb/OeRuCEOPd+JunRpztjEqggD0U99qIB8egYLoQOBUxocr2ZM5xNDkMb8h4q5EpORxlpervPKPmcivx03qMpjPCsiBSQQB4Z0TK2fhmv1Kar94xMM6Aiy3svHzBi0Xo74fsu3pFbk85S1w4342wcoyAzWGVJwt4z1xRJPi6yewbHDDD1Pyu6Z4/CM6RqY5UhRKY
+  template:
+    metadata:
+      annotations:
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
+      name: azure-fce-volume
+      labels:
+        application: fce
+        component: fce
+        owner: fce
+        team: fce
+    type: Opaque
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: strapi
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: strapi
@@ -583,12 +769,15 @@ spec:
       annotations:
         kapp.k14s.io/disable-default-ownership-label-rules: ''
         kapp.k14s.io/disable-default-label-scoping-rules: ''
-        app.gitlab.com/app: socialgouv-fce
-        app.gitlab.com/env: prod
-        app.gitlab.com/env.name: prod
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
       labels:
         app: strapi
         application: fce
+        component: fce
         owner: fce
         team: fce
     spec:
@@ -633,13 +822,16 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   name: strapi-env
   namespace: fce
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
 spec:
@@ -665,12 +857,15 @@ spec:
       annotations:
         kapp.k14s.io/disable-default-ownership-label-rules: ''
         kapp.k14s.io/disable-default-label-scoping-rules: ''
-        app.gitlab.com/app: socialgouv-fce
-        app.gitlab.com/env: prod
-        app.gitlab.com/env.name: prod
+        app.github.com/job: '5678'
+        app.github.com/ref: v1.2.3
+        app.github.com/repo: socialgouv/fce
+        app.github.com/run: '1234'
+        app.github.com/sha: '0123456'
       name: strapi-env
       labels:
         application: fce
+        component: fce
         owner: fce
         team: fce
     type: Opaque
@@ -682,11 +877,14 @@ metadata:
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     application: fce
+    component: fce
     owner: fce
     team: fce
   namespace: fce
@@ -700,15 +898,18 @@ metadata:
   labels:
     app: strapi
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: strapi
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   namespace: fce
 spec:
   ports:
@@ -719,21 +920,24 @@ spec:
     app: strapi
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/tls-acme: 'true'
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
-    app.gitlab.com/app: socialgouv-fce
-    app.gitlab.com/env: prod
-    app.gitlab.com/env.name: prod
+    app.github.com/job: '5678'
+    app.github.com/ref: v1.2.3
+    app.github.com/repo: socialgouv/fce
+    app.github.com/run: '1234'
+    app.github.com/sha: '0123456'
   labels:
     app: strapi
     application: fce
+    component: fce
     owner: fce
     team: fce
   name: strapi
@@ -744,9 +948,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: strapi
-              servicePort: 80
+              service:
+                name: strapi
+                port:
+                  name: http
             path: /
+            pathType: Prefix
   tls:
     - hosts:
         - strapi-fce.fabrique.social.gouv.fr

--- a/.k8s/__tests__/dev.ts
+++ b/.k8s/__tests__/dev.ts
@@ -8,8 +8,6 @@ test("kosko generate --dev", async () => {
   expect(
     await getEnvManifests("dev", "", {
       ...project("fce").dev,
-      CI_COMMIT_TAG: "",
-      CI_COMMIT_SHA: "",
       GITHUB_SHA: "0123456789abcdefghijklmnopqrstuvwxyz0123",
       RANCHER_PROJECT_ID: "c-gjtkk:p-8j5hf",
     })

--- a/.k8s/__tests__/prod.ts
+++ b/.k8s/__tests__/prod.ts
@@ -8,13 +8,9 @@ test("kosko generate --prod", async () => {
   expect(
     await getEnvManifests("prod", "", {
       ...project("fce").prod,
-      // CI_COMMIT_TAG: "",
-      // CI_COMMIT_SHA: "",
       GITHUB_REF: "v1.2.3",
       GITHUB_SHA: "0123456789abcdefghijklmnopqrstuvwxyz0123",
       SOCIALGOUV_PRODUCTION: "true",
-      // PRODUCTION: "true",
-      // PRODUCTION_NAMESPACE: "fce",
       RANCHER_PROJECT_ID: "c-gjtkk:p-8j5hf",
   })).toMatchSnapshot();
 });

--- a/.k8s/__tests__/prod.ts
+++ b/.k8s/__tests__/prod.ts
@@ -1,19 +1,20 @@
 //
 
 import { getEnvManifests } from "@socialgouv/kosko-charts/testing";
-import { project } from "@socialgouv/kosko-charts/testing/fake/gitlab-ci.env";
+import { project } from "@socialgouv/kosko-charts/testing/fake/github-actions.env";
 
 jest.setTimeout(1000 * 60);
 test("kosko generate --prod", async () => {
   expect(
     await getEnvManifests("prod", "", {
       ...project("fce").prod,
-      CI_COMMIT_TAG: "",
-      CI_COMMIT_SHA: "",
+      // CI_COMMIT_TAG: "",
+      // CI_COMMIT_SHA: "",
       GITHUB_REF: "v1.2.3",
       GITHUB_SHA: "0123456789abcdefghijklmnopqrstuvwxyz0123",
-      PRODUCTION: "true",
-      PRODUCTION_NAMESPACE: "fce",
+      SOCIALGOUV_PRODUCTION: "true",
+      // PRODUCTION: "true",
+      // PRODUCTION_NAMESPACE: "fce",
       RANCHER_PROJECT_ID: "c-gjtkk:p-8j5hf",
   })).toMatchSnapshot();
 });

--- a/.k8s/components/client.ts
+++ b/.k8s/components/client.ts
@@ -30,8 +30,6 @@ const createManifests = async () => {
         name: "server",
         port: { name: "http" }
       }
-      // serviceName: "server",
-      // servicePort: 80,
     }
   });
 

--- a/.k8s/components/client.ts
+++ b/.k8s/components/client.ts
@@ -26,9 +26,12 @@ const createManifests = async () => {
     path: "/api",
     pathType: "Prefix",
     backend: {
-      //@ts-expect-error
-      serviceName: "server",
-      servicePort: 80,
+      service: {
+        name: "server",
+        port: { name: "http" }
+      }
+      // serviceName: "server",
+      // servicePort: 80,
     }
   });
 

--- a/.k8s/components/n8n.ts
+++ b/.k8s/components/n8n.ts
@@ -51,12 +51,12 @@ const createManifests = async () => {
       image: getGithubRegistryImagePath(({ project, name })),
       // volumes: [downloadsVolume, dbVolume],
       volumes: [{
-        name: "downloads",
-        azureFile: {
-          readOnly: false,
-          secretName: "azure-fce-volume",
-          shareName: "downloads",
-        },
+        name: "downloads"
+        // azureFile: {
+        //   readOnly: false,
+        //   secretName: "azure-fce-volume",
+        //   shareName: "downloads",
+        // },
       }, {
         name: "n8n-db",
         azureFile: {

--- a/.k8s/components/n8n.ts
+++ b/.k8s/components/n8n.ts
@@ -3,34 +3,9 @@ import env from "@kosko/env";
 import { create } from "@socialgouv/kosko-charts/components/app";
 import { getGithubRegistryImagePath } from "../utils/getGithubRegistryImagePath";
 import { Probe } from "kubernetes-models/v1";
-// import {Probe, Volume, VolumeMount} from "kubernetes-models/v1";
-// import {azureProjectVolume} from "@socialgouv/kosko-charts/components/azure-storage/azureProjectVolume";
 
 const project = "fce";
 const name = "n8n";
-
-// const downloadsVolume = new Volume({
-//   name: "downloads",
-// });
-
-// const downloadsVolumeMount = new VolumeMount({
-//   name: "downloads",
-//   mountPath: "/tmp/download"
-// });
-
-// const [persistentVolumeClaim, persistentVolume] = azureProjectVolume("n8n-db", {
-//   storage: "1Gi"
-// });
-
-// const dbVolume = new Volume({
-//   name: "n8n-db",
-//   persistentVolumeClaim: { claimName: persistentVolumeClaim.metadata!.name! },
-// });
-
-// const dbVolumeMount = new VolumeMount({
-//   mountPath: "/home/node/.n8n",
-//   name: "n8n-db",
-// });
 
 const probe = new Probe({
   httpGet: {
@@ -49,14 +24,8 @@ const createManifests = async () => {
     },
     deployment: {
       image: getGithubRegistryImagePath(({ project, name })),
-      // volumes: [downloadsVolume, dbVolume],
       volumes: [{
         name: "downloads"
-        // azureFile: {
-        //   readOnly: false,
-        //   secretName: "azure-fce-volume",
-        //   shareName: "downloads",
-        // },
       }, {
         name: "n8n-db",
         azureFile: {

--- a/.k8s/package.json
+++ b/.k8s/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@kosko/env": "2",
     "@kubernetes-models/sealed-secrets": "^1.5.4",
-    "@socialgouv/kosko-charts": "7.0.5",
+    "@socialgouv/kosko-charts": "9.5.8",
     "@types/node": "^14.14.31",
     "kosko": "^1.0.3",
     "kubernetes-models": "^1.0.3",

--- a/.k8s/yarn.lock
+++ b/.k8s/yarn.lock
@@ -611,6 +611,15 @@
     node-fetch "^2.6.1"
     tslib "^2.1.0"
 
+"@kubernetes-models/base@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/base/-/base-2.0.1.tgz#162a0d4e68d97e70a1b8cc3df4ac64697d97ed9f"
+  integrity sha512-vaQgb8n4a/yrsVbuxc1M0X3revKkn9apJcgcjtn13mgmaA/P2SNtWrOOeRjE+U8LpYjGREDf24VLL5fl55AGRw==
+  dependencies:
+    "@kubernetes-models/validate" "2.0.1"
+    is-plain-object "^5.0.0"
+    tslib "^2.3.0"
+
 "@kubernetes-models/base@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@kubernetes-models/base/-/base-1.5.5.tgz#6bff274f32e081d15f084853be1322380d2a41b2"
@@ -629,6 +638,25 @@
     "@kubernetes-models/validate" "^1.6.0"
     kubernetes-models "^1.7.1"
     tslib "^2.2.0"
+
+"@kubernetes-models/sealed-secrets@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/sealed-secrets/-/sealed-secrets-2.0.2.tgz#76fda974c52abc6cf3414b32ab4243819889c005"
+  integrity sha512-Nsxc7Hj7hUydp6NYbmpDlr3nhBLCQtrisZ05QF3g8gL9ctKrRh7Djz0QaJlcN+rueDfR0fBdfqM8Nz/EE7RezA==
+  dependencies:
+    "@kubernetes-models/base" "2.0.1"
+    "@kubernetes-models/validate" "2.0.1"
+    kubernetes-models "2.0.2"
+    tslib "^2.3.0"
+
+"@kubernetes-models/validate@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes-models/validate/-/validate-2.0.1.tgz#fe421a08733ff7018f882c1e58a3b7a337964379"
+  integrity sha512-jAXVwj1MJ3T2kEF3l0TYWDvzjVm4z9C7hWxgHKPoNu6zW5/BPxeYhxbCKtXrYRY4WaGWqVUF/6ogwK/vfuisVA==
+  dependencies:
+    ajv "^8.6.2"
+    ajv-formats "^2.1.0"
+    tslib "^2.3.0"
 
 "@kubernetes-models/validate@^1.6.0":
   version "1.6.0"
@@ -660,10 +688,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sindresorhus/is@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
-  integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
+"@sindresorhus/is@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.2.0.tgz#667bfc6186ae7c9e0b45a08960c551437176e1ca"
+  integrity sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -702,14 +730,16 @@
     eslint-import-resolver-typescript "~2.4.0"
     eslint-plugin-import "~2.23.3"
 
-"@socialgouv/kosko-charts@7.0.5":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@socialgouv/kosko-charts/-/kosko-charts-7.0.5.tgz#0b26bfe75087bd60924ff4fde504a350d76d6dac"
-  integrity sha512-z96+osyRTlkUQrYyE8R9w1kfDocEhjM5AXW3/fgufF8HJ4cRPz2Q0E81CRFHr2XWc4LZlHD3UtV3W4Qkqu102A==
+"@socialgouv/kosko-charts@9.5.8":
+  version "9.5.8"
+  resolved "https://registry.yarnpkg.com/@socialgouv/kosko-charts/-/kosko-charts-9.5.8.tgz#b0110dc69d8cd01e3466f944187685657384ce12"
+  integrity sha512-2HlxP7CFUo0fNfwWWX1qUaefO0kDmg4KJcmr5kBaW8C5X7U/PQl86XLOh4vTyl+HZxplHulFZ1LqGN3NXA528Q==
   dependencies:
-    "@sindresorhus/is" "^4.0.1"
+    "@kubernetes-models/sealed-secrets" "^2.0.2"
+    "@sindresorhus/is" "^4.2.0"
     fs-extra "^10.0.0"
-    slugify "^1.5.3"
+    kubernetes-models "^2.0.2"
+    slugify "^1.6.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -1020,6 +1050,16 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.5.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720"
   integrity sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.6.2:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -3368,6 +3408,15 @@ kosko@^1.0.3:
     "@kosko/cli" "1.2.5"
     import-local "^3.0.2"
 
+kubernetes-models@2.0.2, kubernetes-models@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/kubernetes-models/-/kubernetes-models-2.0.2.tgz#d294d31f00a688a1fd205ee59ff680dbf06efa7b"
+  integrity sha512-4tonAim5mF6UFw07wnuEmQSDQ9AaNv54cwsTN32sEVBjrHtItC6RvOUJk36xn3IiFAPLIzwXHpRsjNpnLmbIKw==
+  dependencies:
+    "@kubernetes-models/base" "2.0.1"
+    "@kubernetes-models/validate" "2.0.1"
+    tslib "^2.3.0"
+
 kubernetes-models@^1.0.3, kubernetes-models@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/kubernetes-models/-/kubernetes-models-1.7.1.tgz#e699a3b9454e219ff08d30fc2edaa81c9d3fd127"
@@ -4385,10 +4434,10 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-slugify@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.5.3.tgz#36e009864f5476bfd5db681222643d92339c890d"
-  integrity sha512-/HkjRdwPY3yHJReXu38NiusZw2+LLE2SrhkWJtmlPDB1fqFSvioYj62NkPcrKiNCgRLeGcGK7QBvr1iQwybeXw==
+slugify@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.0.tgz#6bdf8ed01dabfdc46425b67e3320b698832ff893"
+  integrity sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4763,6 +4812,11 @@ tslib@^2.1.0, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
The main goal of these changes is to make the `Kubernetes ingress certificate annotation` compliant with the **new version of the certification manager tool** on the `production` cluster.